### PR TITLE
Rework subscribed event calls

### DIFF
--- a/src/index.subscribe.test.ts
+++ b/src/index.subscribe.test.ts
@@ -24,7 +24,7 @@ describe('subscribe', () => {
     expect(mockSub).toBeCalledTimes(1);
   });
 
-  it('calls subscribed deep property event when relevant state is changed', () => {
+  it('calls deep property event when relevant state is changed', () => {
     /* Setup */
     const { updateState, subscribe } = createStore(initialState);
     const mockSub = jest.fn();

--- a/src/index.subscribe.test.ts
+++ b/src/index.subscribe.test.ts
@@ -10,99 +10,110 @@ const initialState = {
 
 describe('subscribe', () => {
   it('calls event when relevant state is changed', () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub = jest.fn();
     subscribe('a', mockSub);
 
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
 
+    /* Test */
     expect(mockSub).toBeCalledTimes(1);
   });
 
   it('calls subscribed deep property event when relevant state is changed', () => {
-    const newA = 'Broseph';
-    const mockSub = jest.fn();
-
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
+    const mockSub = jest.fn();
     subscribe(['name', 'first'], mockSub);
-    const newState = updateState(d => {
-      d.name.first = newA;
+
+    /* Action */
+    updateState(d => {
+      d.name.first = 'changed';
     });
-    expect(newState.name.first).toBe(newA);
-    // once for 'name', once for 'first'
-    expect(mockSub).toBeCalledTimes(2);
+
+    /* Test */
+    expect(mockSub).toBeCalledTimes(1);
   });
 
   it('calls subscribed event when relevant state is changed with different param versions', () => {
-    const newA = 'world';
-    const mockSub = jest.fn();
-
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
+    const mockSub = jest.fn();
     subscribe('a', mockSub);
     subscribe(['a'], mockSub);
 
-    const newState = updateState(d => {
-      d.a = newA;
+    /* Action */
+    updateState(d => {
+      d.a = 'changed';
     });
 
-    expect(newState.a).toBe(newA);
+    /* Test */
     expect(mockSub).toBeCalledTimes(2);
   });
 
   it("doesn't call event when irrelevant state is changed", () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub1 = jest.fn();
     const mockSub2 = jest.fn();
     subscribe(['name', 'first'], mockSub1);
     subscribe(['name', 'last'], mockSub2);
 
+    /* Action */
     updateState(d => {
       d.name.first = 'changed';
     });
 
-    expect(mockSub1).toBeCalledTimes(2);
-    expect(mockSub2).toBeCalledTimes(1);
+    /* Test */
+    expect(mockSub1).toBeCalledTimes(1);
+    expect(mockSub2).toBeCalledTimes(0);
   });
 
   it('calls event with new state', () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub = jest.fn();
+    const newA = 'changed';
     subscribe('a', mockSub);
 
-    const newState = updateState(d => {
-      d.a = 'changed';
+    /* Action */
+    updateState(d => {
+      d.a = newA;
     });
 
-    expect(mockSub).toBeCalledWith(newState.a);
+    /* Test */
+    expect(mockSub).toBeCalledWith(newA);
   });
 
   it('calls multiple events', () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub1 = jest.fn();
     const mockSub2 = jest.fn();
     subscribe('a', mockSub1);
     subscribe('a', mockSub2);
+
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
+
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(1);
   });
 
   it('calls event when parent changes', () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub = jest.fn();
     subscribe(['name', 'first'], mockSub);
 
+    /* Action */
     updateState(d => {
       d.name = {
         first: 'new',
@@ -110,109 +121,133 @@ describe('subscribe', () => {
       };
     });
 
+    /* Test */
     expect(mockSub).toBeCalledTimes(1);
   });
 
   it('calls event when child changes', () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub = jest.fn();
     subscribe('name', mockSub);
+
+    /* Action */
     updateState(d => {
       d.name.first = 'changed';
     });
+
+    /* Test */
     expect(mockSub).toBeCalledTimes(1);
   });
 
   it("it doesn't call event after unsubscribe", () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub = jest.fn();
     const unsub = subscribe('a', mockSub);
 
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
 
+    /* Test */
     expect(mockSub).toBeCalledTimes(1);
 
+    /* Action */
     unsub();
 
     updateState(d => {
       d.a = 'changed again';
     });
+
+    /* Test */
     expect(mockSub).toBeCalledTimes(1);
   });
 
   it("it doesn't call event after unsubscribe but still calls other events", () => {
+    /* Setup */
     const { updateState, subscribe } = createStore(initialState);
-
     const mockSub1 = jest.fn();
     const mockSub2 = jest.fn();
     const unsub1 = subscribe('a', mockSub1);
     const unsub2 = subscribe('a', mockSub2);
 
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
 
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(1);
 
+    /* Action */
     unsub1();
 
     updateState(d => {
       d.a = 'changed again';
     });
 
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(2);
   });
 
   it("it doesn't unsubscribe the wrong event with different param types 1", () => {
+    /* Setup */
+    const { updateState, subscribe } = createStore(initialState);
     const mockSub1 = jest.fn();
     const mockSub2 = jest.fn();
-
-    const { updateState, subscribe } = createStore(initialState);
-
     const unsub1 = subscribe('a', mockSub1);
     const unsub2 = subscribe(['a'], mockSub2);
 
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
+
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(1);
 
+    /* Action */
     unsub1();
 
     updateState(d => {
       d.a = 'changed again';
     });
+
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(2);
   });
 
   it("it doesn't unsubscribe the wrong event with different param types 2", () => {
+    /* Setup */
+    const { updateState, subscribe } = createStore(initialState);
     const mockSub1 = jest.fn();
     const mockSub2 = jest.fn();
-
-    const { updateState, subscribe } = createStore(initialState);
-
     const unsub1 = subscribe('a', mockSub1);
     const unsub2 = subscribe(['a'], mockSub2);
 
+    /* Action */
     updateState(d => {
       d.a = 'changed';
     });
+
+    /* Test */
     expect(mockSub1).toBeCalledTimes(1);
     expect(mockSub2).toBeCalledTimes(1);
 
+    /* Action */
     unsub2();
 
     updateState(d => {
       d.a = 'changed again';
     });
+
+    /* Test */
     expect(mockSub1).toBeCalledTimes(2);
     expect(mockSub2).toBeCalledTimes(1);
   });

--- a/src/index.updateState.test.ts
+++ b/src/index.updateState.test.ts
@@ -10,24 +10,36 @@ const initialState = {
 
 const newA = 'world';
 const newFirstName = 'james';
+
 describe('updateState', () => {
   it('updates shallow state', () => {
+    /* Setup */
     const { updateState } = createStore(initialState);
+
+    /* Action */
     const newState = updateState(d => {
       d.a = newA;
     });
+
+    /* Test */
     expect(newState.a).toBe(newA);
   });
 
   it('updates deep state', () => {
+    /* Setup */
     const { updateState } = createStore(initialState);
+
+    /* Action */
     const newState = updateState(d => {
       d.name.first = newFirstName;
     });
+
+    /* Test */
     expect(newState.name.first).toBe(newFirstName);
   });
 
   it('updates state from async functions', async () => {
+    /* Setup */
     const { updateState } = createStore(initialState);
     const asyncAction = async () => {
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -36,15 +48,23 @@ describe('updateState', () => {
       });
     };
 
+    /* Action */
     const newState = await asyncAction();
+
+    /* Test */
     expect(newState.a).toBe(newA);
   });
 
   it("doesn't update the wrong state", () => {
+    /* Setup */
     const { updateState } = createStore(initialState);
+
+    /* Action */
     const newState = updateState(d => {
       d.name.first = newFirstName;
     });
+
+    /* Test */
     expect(newState.a).toBe(initialState.a);
   });
 });

--- a/src/index.useStateValue.test.tsx
+++ b/src/index.useStateValue.test.tsx
@@ -25,54 +25,57 @@ const Comp: React.FC<{
 
 describe('useStateValue', () => {
   it('renderes the initial state', () => {
-    // Create store
+    /* Setup */
     const { useStateValue } = createStore(initialState);
     const wrapper = mount(<Comp useState={() => useStateValue('a')} />);
-    // Expect component to render the initial state provided
+
+    /* Test */
     expect(wrapper.find('span').text()).toBe(initialState.a);
   });
 
   it("doesn't try to rerender after unmounting", () => {
+    /* Setup */
     const spy = jest.spyOn(global.console, 'error');
-
-    // Create store
     const { updateState, useStateValue } = createStore(initialState);
     const wrapper = mount(<Comp useState={() => useStateValue('a')} />);
-    // Expect component to render the initial state provided
+
+    /* Test */
     expect(wrapper.find('span').text()).toBe(initialState.a);
 
+    /* Action */
     wrapper.unmount();
-
-    // Perform state change in act to suppress console error
     act(() => {
       updateState(d => {
         d.a = 'changed';
       });
     });
 
+    /* Test */
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('updates shallow state', () => {
+    /* Setup */
     const newA = 'world';
-    // Create store
     const { updateState, useStateValue } = createStore(initialState);
     const wrapper = mount(<Comp useState={() => useStateValue('a')} />);
-    // Expect component to render the initial state provided
+
+    /* Test */
     expect(wrapper.find('span').text()).toBe(initialState.a);
 
-    // Perform state change in act to suppress console error
+    /* Action */
     act(() => {
       updateState(d => {
         d.a = newA;
       });
     });
-    // Expect component to render the new state
+
+    /* Test */
     expect(wrapper.find('span').text()).toBe(newA);
   });
 
   it('rerenders component that uses multiple state', () => {
-    // Create store
+    /* Setup */
     const { updateState, useStateValue } = createStore(initialState);
     const mockfn = jest.fn();
     const CompMulti = () => {
@@ -88,28 +91,37 @@ describe('useStateValue', () => {
       );
     };
     mount(<CompMulti />);
+
+    /* Test */
     expect(mockfn).toBeCalledTimes(1);
 
-    // Perform state change in act to suppress console error
+    /* Action */
     act(() => {
       updateState(d => {
         d.a = 'changes';
       });
     });
+
+    /* Test */
     expect(mockfn).toBeCalledTimes(2);
-    // Perform state change in act to suppress console error
+
+    /* Action */
     act(() => {
       updateState(d => {
         d.name.first = 'changes';
       });
     });
+
+    /* Test */
     expect(mockfn).toBeCalledTimes(3);
   });
 
   it('rerenders only the component that uses the updated state', () => {
-    // Create store
+    /* Setup */
     const { updateState, useStateValue } = createStore(initialState);
     const mockOne = jest.fn();
+    const mockTwo = jest.fn();
+    const mockThree = jest.fn();
     const CompOne = () => (
       <Comp
         useState={() => useStateValue('a')}
@@ -120,7 +132,6 @@ describe('useStateValue', () => {
         }
       />
     );
-    const mockTwo = jest.fn();
     const CompTwo = () => (
       <Comp
         useState={() => useStateValue(['name', 'first'])}
@@ -131,7 +142,6 @@ describe('useStateValue', () => {
         }
       />
     );
-    const mockThree = jest.fn();
     const CompThree = () => (
       <Comp
         useState={() => useStateValue(['name', 'last'])}
@@ -142,7 +152,6 @@ describe('useStateValue', () => {
         }
       />
     );
-
     mount(
       <div>
         <CompOne />
@@ -151,26 +160,30 @@ describe('useStateValue', () => {
       </div>,
     );
 
+    /* Test */
     expect(mockOne).toBeCalledTimes(1);
     expect(mockTwo).toBeCalledTimes(1);
     expect(mockThree).toBeCalledTimes(1);
 
-    // Perform state change in act to suppress console error
+    /* Action */
     act(() => {
       updateState(d => {
         d.a = 'changed';
       });
     });
 
+    /* Test */
     expect(mockOne).toBeCalledTimes(2);
     expect(mockTwo).toBeCalledTimes(1);
     expect(mockThree).toBeCalledTimes(1);
   });
 
   it('rerenders components that use parent state of changed child state', () => {
-    // Create store
+    /* Setup */
     const { updateState, useStateValue } = createStore(initialState);
     const mockOne = jest.fn();
+    const mockTwo = jest.fn();
+    const mockThree = jest.fn();
     const CompOne = () => (
       <Comp
         useState={() => useStateValue('a')}
@@ -181,7 +194,6 @@ describe('useStateValue', () => {
         }
       />
     );
-    const mockTwo = jest.fn();
     const CompTwo = () => (
       <Comp
         useState={() => useStateValue('name')}
@@ -192,7 +204,6 @@ describe('useStateValue', () => {
         }
       />
     );
-    const mockThree = jest.fn();
     const CompThree = () => (
       <Comp
         useState={() => useStateValue(['name', 'first'])}
@@ -203,7 +214,6 @@ describe('useStateValue', () => {
         }
       />
     );
-
     mount(
       <div>
         <CompOne />
@@ -212,17 +222,19 @@ describe('useStateValue', () => {
       </div>,
     );
 
+    /* Test */
     expect(mockOne).toBeCalledTimes(1);
     expect(mockTwo).toBeCalledTimes(1);
     expect(mockThree).toBeCalledTimes(1);
 
-    // Perform state change in act to suppress console error
+    /* Action */
     act(() => {
       updateState(d => {
         d.name.first = 'changed';
       });
     });
 
+    /* Test */
     expect(mockOne).toBeCalledTimes(1);
     expect(mockTwo).toBeCalledTimes(2);
     expect(mockThree).toBeCalledTimes(2);


### PR DESCRIPTION
This fixes the issue of subscribed events being called multiple times and removes the need to chain deeply into the changes to emit subscribed events